### PR TITLE
turf modules are now namespaced

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var isects = require('geojson-polygon-self-intersections');
-var helpers = require('turf-helpers');
-var within = require('turf-within');
-var area = require('turf-area');
+var helpers = require('@turf/helpers');
+var within = require('@turf/within');
+var area = require('@turf/area');
 var rbush = require('rbush');
 
 /**
@@ -84,7 +84,7 @@ module.exports = function(feature) {
     pseudoVtxListByRingAndEdge.push([]);
     for (var j = 0; j < feature.geometry.coordinates[i].length-1; j++) {
       // Each edge will feature one ring-pseudo-vertex in its array, on the last position. i.e. edge j features the ring-pseudo-vertex of the ring vertex j+1, which has ringAndEdgeIn = [i,j], on the last position.
-    	pseudoVtxListByRingAndEdge[i].push([new PseudoVtx(feature.geometry.coordinates[i][(j+1).modulo(feature.geometry.coordinates[i].length-1)], 1, [i, j], [i, (j+1).modulo(feature.geometry.coordinates[i].length-1)], undefined)]);
+      pseudoVtxListByRingAndEdge[i].push([new PseudoVtx(feature.geometry.coordinates[i][(j+1).modulo(feature.geometry.coordinates[i].length-1)], 1, [i, j], [i, (j+1).modulo(feature.geometry.coordinates[i].length-1)], undefined)]);
       // The first numvertices elements in isectList correspond to the ring-vertex-intersections
       isectList.push(new Isect(feature.geometry.coordinates[i][j], [i, (j-1).modulo(feature.geometry.coordinates[i].length-1)], [i, j], undefined, undefined, false, true));
     }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "url": "https://github.com/mclaeysb/simplepolygon/issues"
   },
   "dependencies": {
+    "@turf/area": "^3.13.0",
+    "@turf/helpers": "^3.13.0",
+    "@turf/within": "^3.13.0",
     "geojson-polygon-self-intersections": "^1.1.1",
-    "rbush": "^2.0.1",
-    "turf-area": "^3.0.0",
-    "turf-helpers": "^3.0.0",
-    "turf-within": "^3.0.0"
+    "rbush": "^2.0.1"
   },
   "devDependencies": {},
   "homepage": "https://github.com/mclaeysb/simplepolygon#readme"


### PR DESCRIPTION
TurfJS modules are now using namespaces under `@turf/<module>`.

**Install warning messages:**

```bash
$ npm install simplepolygon
npm WARN deprecated turf-area@3.0.12: Turf packages are now namespaced: please use @tu
rf/area instead
npm WARN deprecated turf-within@3.0.12: Turf packages are now namespaced: please use @
turf/within instead
npm WARN deprecated turf-helpers@3.0.12: Turf packages are now namespaced: please use
@turf/helpers instead
npm WARN deprecated geojson-area@0.2.1: This module is now under the @mapbox namespace
: install @mapbox/geojson-area instead
npm WARN deprecated turf-inside@3.0.12: Turf packages are now namespaced: please use @
turf/inside instead
npm WARN deprecated turf-invariant@3.0.12: Turf packages are now namespaced: please us
e @turf/invariant instead
test@1.0.0 /Users/mac/Github/test
└─┬ simplepolygon@1.1.1
  ├── geojson-polygon-self-intersections@1.1.1
  ├─┬ turf-area@3.0.12
  │ └── geojson-area@0.2.1
  ├── turf-helpers@3.0.12
  └─┬ turf-within@3.0.12
    └─┬ turf-inside@3.0.12
      └── turf-invariant@3.0.12
```