### PR TITLE
Updates turf deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function(feature) {
   debug("Setting up pseudoVtxListByRingAndEdge and isectList");
 
   // Make a spatial index of intersections, in preperation for the following two steps
-  allIsectsAsIsectRbushTreeItem = [];
+  var allIsectsAsIsectRbushTreeItem = [];
   for (var i = 0; i < numIsect; i++) {
     allIsectsAsIsectRbushTreeItem.push({minX: isectList[i].coord[0], minY: isectList[i].coord[1], maxX: isectList[i].coord[0], maxY: isectList[i].coord[1], index: i}); // could pass isect: isectList[i], but not necessary
   }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "url": "https://github.com/mclaeysb/simplepolygon/issues"
   },
   "dependencies": {
-    "@turf/area": "^3.13.0",
-    "@turf/helpers": "^3.13.0",
+    "@turf/area": "^4.5.0",
+    "@turf/helpers": "^4.5.0",
     "@turf/inside": "^4.5.2",
-    "@turf/within": "^3.13.0",
+    "@turf/within": "^4.5.0",
     "debug": "^2.6.3",
     "geojson-polygon-self-intersections": "^1.1.2",
     "rbush": "^2.0.1"


### PR DESCRIPTION
Updates turf dependencies 

 - turf/area
 - turf/helpers
 - turf/inside
 - turf/within

to their `^4.x` counterparts, since depending on versions `^3.x` did create unnecesary duplicate versions in the `node_modules` folder (and, in my case, also in the `jspm_packages` folder).

The tests are passing flawlessly

This PR already contains #15, so it can be merge either ignoring #15 or after #15. 


**If you accept this PR, please do tag it and publish to npm so I can update this dependency on my projects :fireworks:** 
